### PR TITLE
修改 \ 为 /

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function(options) {
 
             includeSrc = path.join(options.baseSrc || "", includeSrc);
 
-            var name = includeSrc.split("\/")[includeSrc.split('\/').length - 1].split('.')[0];
+            var name = includeSrc.split("\/")[includeSrc.split('\/').length - 1].split('.')[0].replace(/\\/g,'/');
 
             var promise = fs.readFileAsync(includeSrc)
                 .then(function(data) {


### PR DESCRIPTION
windows下的路径分隔符为 \，~
(引用文档)[https://nodejs.org/dist/latest-v6.x/docs/api/path.html#path_path_sep]